### PR TITLE
Feature/symfony 5 4 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ strings(currently `high` is unavailable), `low` and `medium`. Defaults:
 ```
 
 ### `SecureBytesGenerator`
-Generates a secure random byte string using the `Symfony\Component\Security\Core\Util\SecureRandom` class. Defaults:
+Generates a secure random byte string using the `random_bytes()`. Defaults:
 
 ```php
 @Generate(generator="secure_bytes", options={"length"=8})

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,10 @@
     "require": {
         "php": ">=7.1",
         "doctrine/orm": "^2.6",
-        "symfony/security": "^3.3|^4.0",
-        "symfony/options-resolver": "^3.0|^4.0",
+        "symfony/options-resolver": "^4.0|^5.0",
         "ircmaxell/random-lib": "~1.0",
-        "symfony/dependency-injection": "^3.3|^4.0",
-        "symfony/config": "^3.3|^4.0"
+        "symfony/dependency-injection": "^4.0|^5.0",
+        "symfony/config": "^4.0|^5.0"
     },
     "suggest": {
         "ramsey/uuid": "To use the UUID generator you should require this package"

--- a/src/Vivait/StringGeneratorBundle/Generator/SecureBytesGenerator.php
+++ b/src/Vivait/StringGeneratorBundle/Generator/SecureBytesGenerator.php
@@ -7,10 +7,6 @@ use Vivait\StringGeneratorBundle\Model\ConfigurableGeneratorInterface;
 
 class SecureBytesGenerator implements ConfigurableGeneratorInterface
 {
-    /**
-     * @var SecureRandom
-     */
-    private $secureRandom;
     private $length = 8;
 
     /**


### PR DESCRIPTION
symfony/security deprecated its only usage here. It seems the package owner did replace the SecureRandom, but didn't remove the dependencies.  https://github.com/onlyfyio/StringGeneratorBundle/commit/4f5f59baee2db41a1d086815ecd8fc9d206aabb1

 * deprecated the `Symfony\Component\Security\Core\Util\SecureRandom` class in favor of the `random_bytes()` function

https://github.com/symfony/security/blob/b3eab8b37ff7b24d9c582770fd1cd57725895e3b/CHANGELOG.md?plain=1#L128